### PR TITLE
No more symlinks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,6 +69,7 @@ VOLUME /home/steam/.steam/steamapps
 VOLUME /ark
 # optionally shared volumes between servers in a cluster
 VOLUME /arkserver
-VOLUME /arkclusters
+# mount /arkserver/ShooterGame/Saved seperate for each server
+# mount /arkserver/ShooterGame/Saved/clusters shared for all servers
 
 CMD [ "./run.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,16 @@ FROM drpsychick/steamcmd:$STEAMCMD_VERSION AS base
 USER root
 
 RUN apt-get update \
-    && apt-get install -y curl cron bzip2 perl-modules lsof libc6-i386 lib32gcc1 sudo \
+    && apt-get install -y \
+    curl \
+    cron \
+    bzip2 \
+    perl-modules \
+    lsof \
+    libc6-i386 \
+    lib32gcc1 \
+    libsdl2-2.0.0:i386 \
+    sudo \
     && apt-get autoremove -y \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/* \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG STEAMCMD_VERSION=latest
 ARG AMG_BUILD=latest
 ARG AMG_VERSION=v1.6.57
-FROM thmhoag/steamcmd:$STEAMCMD_VERSION AS base
+FROM drpsychick/steamcmd:$STEAMCMD_VERSION AS base
 
 USER root
 

--- a/run.sh
+++ b/run.sh
@@ -169,7 +169,10 @@ if [ "$LIST_MOUNTS" = "true" ]; then
     echo "--> $d"
     ls -la $d
   done
-  [ "$ARKCLUSTER" = "true" ] && ls -la $ARKSERVER/ShooterGame/Saved/clusters
+  if [ "$ARKCLUSTER" = "true" ]; then
+    echo "--> $ARKSERVER/ShooterGame/Saved/clusters"
+    ls -la $ARKSERVER/ShooterGame/Saved/clusters
+  fi
   mount | grep "on /ark"
   exit 0
 fi

--- a/run.sh
+++ b/run.sh
@@ -14,7 +14,16 @@ echo "##########################################################################
 echo "Ensuring correct permissions..."
 sudo find /ark -not -user steam -o -not -group steam -exec chown -v steam:steam {} \;
 sudo find /home/steam -not -user steam -o -not -group steam -exec chown -v steam:steam {} \;
-[ -n "$ARKSERVER_SHARED" ] && sudo find $ARKSERVER_SHARED -not -user steam -o -not -group steam -exec chown -v steam:steam {} \;
+if [ -n "$ARKSERVER_SHARED" ]; then
+  sudo find $ARKSERVER_SHARED -not -user steam -o -not -group steam -exec chown -v steam:steam {} \;
+  echo "Shared server files in $ARKSERVER_SHARED..."
+  if [ -z "$(mount | grep "on $ARKSERVER_SHARED/ShooterGame/Saved")" ]; then
+    echo "===> ABORT !"
+    echo "You seem to be using a shared server directory: '$ARKSERVER_SHARED'"
+    echo "But you have NOT mounted your game instance saved directory to '$ARKSERVER_SHARED/ShooterGame/Saved'"
+    exit 1
+  fi
+fi
 
 # Remove arkmanager tracking files if they exist
 # They can cause issues with starting the server multiple times
@@ -41,16 +50,6 @@ if [ ! -d $ARKSERVER/ShooterGame/Binaries ]; then
   mkdir -p $ARKSERVER/ShooterGame/Saved/$am_ark_AltSaveDirectoryName
 	mkdir -p $ARKSERVER/ShooterGame/Content/Mods
 	mkdir -p $ARKSERVER/ShooterGame/Binaries/Linux/
-fi
-
-if [ -n "$ARKSERVER_SHARED" ]; then
-  echo "Shared server files in $ARKSERVER_SHARED..."
-  if [ -z "$(mount | grep "on $ARKSERVER_SHARED/ShooterGame/Saved")" ]; then
-    echo "===> ABORT !"
-    echo "You seem to be using a shared server directory: '$ARKSERVER_SHARED'"
-    echo "But you have NOT mounted your game instance saved directory to '$ARKSERVER_SHARED/ShooterGame/Saved'"
-    exit 1
-  fi
 fi
 
 if [ "$ARKCLUSTER" = "true" -a ! -L $ARKSERVER/ShooterGame/Saved/clusters ]; then

--- a/run.sh
+++ b/run.sh
@@ -14,6 +14,7 @@ echo "##########################################################################
 echo "Ensuring correct permissions..."
 sudo find /ark -not -user steam -o -not -group steam -exec chown -v steam:steam {} \;
 sudo find /home/steam -not -user steam -o -not -group steam -exec chown -v steam:steam {} \;
+[ -n "$ARKSERVER_SHARED" ] && sudo find $ARKSERVER_SHARED -not -user steam -o -not -group steam -exec chown -v steam:steam {} \;
 
 # Remove arkmanager tracking files if they exist
 # They can cause issues with starting the server multiple times
@@ -43,8 +44,7 @@ if [ ! -d $ARKSERVER/ShooterGame/Binaries ]; then
 fi
 
 if [ -n "$ARKSERVER_SHARED" ]; then
-  echo "Shared server files in $ARKSERVER_SHARED, ensuring correct permissions..."
-	sudo find $ARKSERVER -not -user steam -o -not -group steam -exec chown -v steam:steam {} \;
+  echo "Shared server files in $ARKSERVER_SHARED..."
   if [ -z "$(mount | grep "on $ARKSERVER_SHARED/ShooterGame/Saved")" ]; then
     echo "===> ABORT !"
     echo "You seem to be using a shared server directory: '$ARKSERVER_SHARED'"

--- a/run.sh
+++ b/run.sh
@@ -42,14 +42,6 @@ if [ ! -d /ark/server/ShooterGame/Binaries ]; then
 	mkdir -p /ark/server/ShooterGame/Binaries/Linux/
 fi
 
-# default
-# /ark/server per server
-# /ark/server/ShooterGame/Saved is symlinked to /ark/saved
-
-# shared server directory
-# /ark/server is shared
-# /ark/server/ShooterGame/Saved is symlinked to /ark/saved
-
 # migrate Saved directory first
 if [ ! -L /ark/server/ShooterGame/Saved ]; then
   if [ -d /ark/server/ShooterGame/Saved/SavedArks -a -d /ark/saved/SavedArks ]; then
@@ -90,6 +82,7 @@ if [ -n "$ARKSERVER_SHARED" -a -d "$ARKSERVER_SHARED" ]; then
   export am_arkStagingDir=
 fi
 
+# /ark/server/ShooterGame/Saved is always symlinked to /ark/saved
 # ensure that Saved directory is linked to /ark/saved
 if [ ! -L /ark/server/ShooterGame/Saved ]; then
   echo "ABORT: Saved not symlinked"
@@ -179,7 +172,7 @@ else
 	echo "Save file validation is not enabled."
 fi
 
-if [[ $BACKUP_ONSTART = true ]]; then
+if [ "$BACKUP_ONSTART" = "true" ]; then
 	echo "Backing up on start..."
 	arkmanager backup
 else
@@ -200,6 +193,14 @@ trap stop TERM
 # log from RCON to stdout
 if [ $LOG_RCONCHAT -gt 0 ]; then
   bash -c ./log.sh &
+fi
+
+if [ "$TEST_MIGRATION" = "true" ]; then
+  echo "TEST Migration result: ARKSERVER_SHARED=$ARKSERVER_SHARED ARKCLUSTER=$ARKCLUSTER"
+  ls -la /ark
+  ls -la /ark/server/ShooterGame/
+  ls -la /ark/server/ShooterGame/Saved/
+  exit 0
 fi
 
 arkmanager start --no-background --verbose &

--- a/run.sh
+++ b/run.sh
@@ -15,7 +15,8 @@ echo "Ensuring correct permissions..."
 sudo find /ark -not -user steam -o -not -group steam -exec chown -v steam:steam {} \;
 sudo find /home/steam -not -user steam -o -not -group steam -exec chown -v steam:steam {} \;
 if [ -n "$ARKSERVER_SHARED" ]; then
-  sudo find $ARKSERVER_SHARED -not -user steam -o -not -group steam -exec chown -v steam:steam {} \;
+  # directory is created when something is mounted to 'Saved'
+  sudo chown steam:steam $ARKSERVER_SHARED/ShooterGame
   echo "Shared server files in $ARKSERVER_SHARED..."
   if [ -z "$(mount | grep "on $ARKSERVER_SHARED/ShooterGame/Saved")" ]; then
     echo "===> ABORT !"

--- a/run.sh
+++ b/run.sh
@@ -16,7 +16,7 @@ sudo find /ark -not -user steam -o -not -group steam -exec chown -v steam:steam 
 sudo find /home/steam -not -user steam -o -not -group steam -exec chown -v steam:steam {} \;
 if [ -n "$ARKSERVER_SHARED" ]; then
   # directory is created when something is mounted to 'Saved'
-  sudo chown steam:steam $ARKSERVER_SHARED/ShooterGame
+  [ -d "$ARKSERVER_SHARED/ShooterGame" ] && sudo chown steam:steam $ARKSERVER_SHARED/ShooterGame
   echo "Shared server files in $ARKSERVER_SHARED..."
   if [ -z "$(mount | grep "on $ARKSERVER_SHARED/ShooterGame/Saved")" ]; then
     echo "===> ABORT !"

--- a/run.sh
+++ b/run.sh
@@ -43,7 +43,8 @@ if [ ! -d $ARKSERVER/ShooterGame/Binaries ]; then
 fi
 
 if [ -n "$ARKSERVER_SHARED" ]; then
-  echo "Shared server files in $ARKSERVER_SHARED..."
+  echo "Shared server files in $ARKSERVER_SHARED, ensuring correct permissions..."
+	sudo find $ARKSERVER -not -user steam -o -not -group steam -exec chown -v steam:steam {} \;
   if [ -z "$(mount | grep "on $ARKSERVER_SHARED/ShooterGame/Saved")" ]; then
     echo "===> ABORT !"
     echo "You seem to be using a shared server directory: '$ARKSERVER_SHARED'"

--- a/test/ark-thecenter.env
+++ b/test/ark-thecenter.env
@@ -1,0 +1,15 @@
+am_ark_SessionName=Ark Server
+am_serverMap=TheCenter
+am_ark_ServerAdminPassword=k3yb04rdc4t
+am_ark_ServerPassword=
+am_ark_MaxPlayers=10
+am_ark_QueryPort=27015
+am_ark_Port=7778
+am_ark_RCONPort=32330
+#am_ark_AltSaveDirectoryName=SavedArks
+#am_arkwarnminutes=15
+#am_arkAutoUpdateOnStart=false
+am_ark_GameModIds=889745138,731604991,893904615,564895376,931434275,1404697612,621154190
+#ARKCLUSTER=true
+#am_arkStagingDir=
+#ARKSERVER_SHARED=/arkserver

--- a/test/ark-theisland.env
+++ b/test/ark-theisland.env
@@ -1,0 +1,15 @@
+am_ark_SessionName=Ark Server
+am_serverMap=TheIsland
+am_ark_ServerAdminPassword=k3yb04rdc4t
+am_ark_ServerPassword=
+am_ark_MaxPlayers=10
+am_ark_QueryPort=27015
+am_ark_Port=7778
+am_ark_RCONPort=32330
+#am_ark_AltSaveDirectoryName=SavedArks
+#am_arkwarnminutes=15
+am_arkAutoUpdateOnStart=true
+am_ark_GameModIds=889745138,731604991,893904615,564895376,931434275,1404697612,621154190
+ARKCLUSTER=true
+ARKSERVER_SHARED=/arkserver
+#am_arkStagingDir=

--- a/test/run-test.sh
+++ b/test/run-test.sh
@@ -1,0 +1,131 @@
+#!/bin/bash
+
+IMAGE=drpsychick/arkclusters
+TAG=focal
+(cd ..; docker build --build-arg STEAMCMD_VERSION=$TAG --tag $IMAGE:$TAG .)
+#docker pull $IMAGE:$TAG
+
+function testDirectoriesExist() {
+  nok=0
+  if [ ! -d "$1/backup" ]; then nok=$((nok+1)); echo "/backup is missing!"; fi
+  if [ ! -d "$1/config" ]; then nok=$((nok+1)); echo "/config is missing!"; fi
+  if [ ! -d "$1/log" ]; then nok=$((nok+1)); echo "/log is missing!"; fi
+  if [ ! -d "$1/saved" ]; then nok=$((nok+1)); echo "/saved is missing!"; fi
+
+  if [ $nok -gt 0 ]; then
+    echo "FAIL: $nok errors"
+  fi
+}
+
+function testNewSimpleServer() {
+  echo "====> TEST $FUNCNAME"
+  mkdir -p ark-theisland
+
+  serverdir=ark-theisland
+  docker run --rm -it --name $serverdir \
+    --env-file $serverdir.env \
+    -v $PWD/$serverdir:/ark \
+    -e ARKCLUSTER=false \
+    -e ARKSERVER_SHARED= \
+    -e LIST_MOUNTS=true \
+    $IMAGE:$TAG
+  [ $? -ne 0 ] && echo "FAIL: docker exec failed"
+
+  testDirectoriesExist $serverdir
+
+  rm -rf ark-theisland
+}
+
+function testNewSharedServerFail() {
+  echo "====> TEST $FUNCNAME"
+  mkdir -p ark-theisland arkserver arkclusters
+
+  serverdir=ark-theisland
+  docker run --rm -it --name $serverdir \
+    --env-file $serverdir.env \
+    -v $PWD/$serverdir:/ark \
+    -v $PWD/arkclusters:/arkclusters \
+    -v $PWD/arkserver:/arkserver \
+    -e LIST_MOUNTS=true \
+    $IMAGE:$TAG
+  [ $? -eq 0 ] && echo "FAIL: docker failure expected!"
+
+  testDirectoriesExist $serverdir
+
+  rm -rf ark-theisland arkserver arkclusters
+}
+function testNewSharedServer() {
+  echo "====> TEST $FUNCNAME"
+  mkdir -p ark-theisland/saved arkserver arkclusters
+
+  serverdir=ark-theisland
+  docker run --rm -it --name $serverdir \
+    --env-file $serverdir.env \
+    -v $PWD/$serverdir:/ark \
+    -v $PWD/$serverdir/saved:/arkserver/ShooterGame/Saved \
+    -v $PWD/arkclusters:/arkclusters \
+    -v $PWD/arkserver:/arkserver \
+    -e LIST_MOUNTS=true \
+    $IMAGE:$TAG
+  [ $? -ne 0 ] && echo "FAIL: docker failed!"
+
+  testDirectoriesExist $serverdir
+
+  rm -rf ark-theisland arkserver arkclusters
+}
+
+function testMigratedServer() {
+  echo "====> TEST $FUNCNAME"
+  mkdir -p ark-theisland arkserver arkclusters
+  mkdir -p ark-theisland/server/ShooterGame/Binaries
+  mkdir -p ark-theisland/server/ShooterGame/Saved/SavedArks
+  mkdir -p ark-theisland/saved/SavedArks
+  touch ark-theisland/server/ShooterGame/Saved/SavedArks/savegame-dead.dat
+  touch ark-theisland/saved/SavedArks/savegame-good.dat
+
+  serverdir=ark-theisland
+  docker run --rm -it --name $serverdir \
+    --env-file $serverdir.env \
+    -v $PWD/$serverdir:/ark \
+    -v $PWD/$serverdir/saved:/arkserver/ShooterGame/Saved \
+    -v $PWD/arkclusters:/arkclusters \
+    -v $PWD/arkserver:/arkserver \
+    -e LIST_MOUNTS=true \
+    $IMAGE:$TAG
+  [ $? -ne 0 ] && echo "FAIL: docker exec failed"
+
+  testDirectoriesExist $serverdir
+
+  rm -rf ark-theisland arkserver arkclusters
+}
+
+###
+function testSharedMount() {
+  echo "====> TEST $FUNCNAME"
+  mkdir -p ark-theisland arkserver arkclusters
+  mkdir -p ark-theisland/server/ShooterGame/Binaries
+  mkdir -p ark-theisland/saved/SavedArks
+  touch ark-theisland/saved/SavedArks/savegame.dat
+
+  serverdir=ark-theisland
+  docker run --rm -it --name $serverdir \
+    --env-file $serverdir.env \
+    -v $PWD/$serverdir:/ark \
+    -v $PWD/$serverdir/saved:/arkserver/ShooterGame/Saved \
+    -v $PWD/arkclusters:/arkclusters \
+    -v $PWD/arkserver:/arkserver \
+    -e LIST_MOUNTS=true \
+    $IMAGE:$TAG
+  [ $? -ne 0 ] && echo "FAIL: docker exec failed"
+
+  testDirectoriesExist $serverdir
+
+  rm -rf ark-theisland arkserver arkclusters
+}
+
+testNewSimpleServer
+testNewSharedServerFail
+testNewSharedServer
+testMigratedServer
+testSharedMount
+

--- a/test/run-test.sh
+++ b/test/run-test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-IMAGE=drpsychick/arkclusters
+IMAGE=drpsychick/arkcluster
 TAG=focal
 (cd ..; docker build --build-arg STEAMCMD_VERSION=$TAG --tag $IMAGE:$TAG .)
 #docker pull $IMAGE:$TAG
@@ -10,7 +10,6 @@ function testDirectoriesExist() {
   if [ ! -d "$1/backup" ]; then nok=$((nok+1)); echo "/backup is missing!"; fi
   if [ ! -d "$1/config" ]; then nok=$((nok+1)); echo "/config is missing!"; fi
   if [ ! -d "$1/log" ]; then nok=$((nok+1)); echo "/log is missing!"; fi
-  if [ ! -d "$1/saved" ]; then nok=$((nok+1)); echo "/saved is missing!"; fi
 
   if [ $nok -gt 0 ]; then
     echo "FAIL: $nok errors"

--- a/test/run-test.sh
+++ b/test/run-test.sh
@@ -62,7 +62,7 @@ function testNewSharedServer() {
     --env-file $serverdir.env \
     -v $PWD/$serverdir:/ark \
     -v $PWD/$serverdir/saved:/arkserver/ShooterGame/Saved \
-    -v $PWD/arkclusters:/arkclusters \
+    -v $PWD/arkclusters:/arkserver/ShooterGame/Saved/clusters \
     -v $PWD/arkserver:/arkserver \
     -e LIST_MOUNTS=true \
     $IMAGE:$TAG
@@ -87,7 +87,7 @@ function testMigratedServer() {
     --env-file $serverdir.env \
     -v $PWD/$serverdir:/ark \
     -v $PWD/$serverdir/saved:/arkserver/ShooterGame/Saved \
-    -v $PWD/arkclusters:/arkclusters \
+    -v $PWD/arkclusters:/arkserver/ShooterGame/Saved/clusters \
     -v $PWD/arkserver:/arkserver \
     -e LIST_MOUNTS=true \
     $IMAGE:$TAG
@@ -111,7 +111,7 @@ function testSharedMount() {
     --env-file $serverdir.env \
     -v $PWD/$serverdir:/ark \
     -v $PWD/$serverdir/saved:/arkserver/ShooterGame/Saved \
-    -v $PWD/arkclusters:/arkclusters \
+    -v $PWD/arkclusters:/arkserver/ShooterGame/Saved/clusters \
     -v $PWD/arkserver:/arkserver \
     -e LIST_MOUNTS=true \
     $IMAGE:$TAG


### PR DESCRIPTION
* keep default behaviour: only mount `/ark`
* no migration, just checks that keep from starting with wrong config
* optionally mount `/arkserver` for shared server files, BUT
   * you must mount `/arkserver/ShooterGame/Saved` as well
   * and if you run a cluster, `/arkserver/ShooterGame/Saved/clusters` as well
 